### PR TITLE
feat: add streamable http transport option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Agent Notes
+
+## Reasoning
+
+- Introduced an `MCP_TRANSPORT` environment variable so the server can switch between stdio and Streamable HTTP transports. Stdio remains the default for compatibility.
+- When `MCP_TRANSPORT=streamable-http`, a lightweight HTTP server is created and requests are passed to the MCP transport. The port can be configured via `PORT` (defaults to `3000`).
+- README and CLI help now document how to launch the server with the Streamable HTTP transport for clients that can't use stdio.
+- Added a `--port` flag so the HTTP port can be set directly when launching via `npx`, which maps to the same `PORT` environment variable.
+
+These notes explain why the environment variable exists and how to run the server in each mode.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ Drop this into your client’s mcp.json (e.g. .vscode/mcp.json, ~/.cursor/mcp.js
 
 
 
+### Streamable HTTP transport
+
+By default the server uses stdio. To run it over HTTP instead:
+
+```bash
+MCP_TRANSPORT=streamable-http npx -y @just-every/mcp-read-website-fast --port 8080
+```
+
+The server listens on port `3000` by default. Override it with `--port` or the `PORT` env variable.
+
 ## Features
 
 - **Fast startup** using official MCP SDK with lazy loading for optimal performance

--- a/bin/mcp-read-website.js
+++ b/bin/mcp-read-website.js
@@ -9,8 +9,8 @@ const __dirname = dirname(__filename);
 const args = process.argv.slice(2);
 
 async function main() {
-  // Default to 'serve' if no arguments provided (for MCP usage)
-  const command = args[0] || 'serve';
+  // Default to 'serve' if no command or first arg is an option
+  const command = args[0] && !args[0].startsWith('-') ? args[0] : 'serve';
   
   // Check if compiled dist exists
   const distExists = existsSync(join(__dirname, '..', 'dist'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,10 @@ program
     .option('-u, --user-agent <string>', 'Custom user agent')
     .option('--cache-dir <path>', 'Cache directory', '.cache')
     .option('-t, --timeout <ms>', 'Request timeout in milliseconds', '30000')
-    .option('--cookies-file <path>', 'Path to Netscape cookie file for authenticated pages')
+    .option(
+        '--cookies-file <path>',
+        'Path to Netscape cookie file for authenticated pages'
+    )
     .option(
         '-o, --output <format>',
         'Output format: json, markdown, or both',
@@ -44,7 +47,7 @@ program
         try {
             const pages = parseInt(options.pages, 10);
             const depth = pages > 1 ? 1 : 0; // If more than 1 page requested, crawl 1 level deep
-            
+
             const crawlOptions: CrawlOptions = {
                 depth: depth,
                 maxConcurrency: parseInt(options.concurrency, 10),
@@ -60,7 +63,7 @@ program
             }
 
             console.error(`Fetching ${url}...`);
-            
+
             if (options.output === 'json') {
                 const results = await fetch(url, crawlOptions);
                 console.log(JSON.stringify(results, null, 2));
@@ -69,12 +72,12 @@ program
                     ...crawlOptions,
                     maxPages: pages,
                 });
-                
+
                 // Output the combined markdown
                 if (result.markdown) {
                     console.log(result.markdown);
                 }
-                
+
                 // Show error if any
                 if (result.error) {
                     console.error(`Error: ${result.error}`);
@@ -119,7 +122,9 @@ program
 
 program
     .command('serve')
-    .description('Run as an MCP server')
+    .description(
+        'Run as an MCP server (set MCP_TRANSPORT=streamable-http for HTTP transport; use --port or PORT to change the port)'
+    )
     .action(async () => {
         // Import and run the serve module
         await import('./serve.js');

--- a/src/serve-restart.ts
+++ b/src/serve-restart.ts
@@ -6,6 +6,18 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// Allow setting PORT via --port flag
+const args = process.argv.slice(2);
+for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--port' || arg === '-p') {
+        const value = args[i + 1];
+        if (value) process.env.PORT = value;
+    } else if (arg.startsWith('--port=')) {
+        process.env.PORT = arg.split('=')[1];
+    }
+}
+
 // Configuration
 const MAX_RESTART_ATTEMPTS = 10;
 const RESTART_WINDOW_MS = 60000; // 1 minute


### PR DESCRIPTION
## Summary
- allow selecting Streamable HTTP or stdio transport via `MCP_TRANSPORT`
- allow specifying HTTP port via `--port`/`PORT` when launching via `npx`
- document HTTP transport usage in CLI help and README
- record reasoning in `AGENTS.md`

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint` *(fails: prettier/prettier errors in existing files)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b1af38cc5883308a349299c1c75b10