### PR TITLE
feat: fastmcp 3.4.2 uplift — annotations, structured output, resources, prompts, context

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Fetch a web page and return clean Markdown.
 | `timeout_seconds` | int (5-120) | 30 | Per-page timeout. Increase for JS-heavy sites |
 | `max_chars` | int (0-500000) | 50000 | Max characters returned. 0 = unlimited |
 
+Returns a structured result (`url`, `markdown`, `title`, `links`, `error`, plus crawl page counts `pages_requested` / `pages_fetched` / `pages_failed`) so clients get a machine-readable `output_schema` instead of re-parsing a JSON string. Multi-page crawls report progress via the MCP context as each page is fetched.
+
 **Examples:**
 ```
 # Read a single page
@@ -89,6 +91,27 @@ Returns cache size and file count.
 ### `clear_cache`
 
 Clears the on-disk cache. Use when stale content is suspected.
+
+> Tools are tagged `read` (the two content tools) and `cache-admin` (`get_cache_status`, `clear_cache`) so deployments can gate or hide the destructive cache tool via FastMCP `include_tags` / `exclude_tags`.
+
+## MCP Resources
+
+Readable reference data (no side effects), under the `readwebsite://` URI scheme:
+
+| Resource | Description |
+|----------|-------------|
+| `readwebsite://config` | Effective runtime config and the hard limits the crawler enforces |
+| `readwebsite://cache/status` | Current cache size and file count |
+| `readwebsite://usage` | Guidance on choosing tools and tuning crawl parameters |
+
+## MCP Prompts
+
+Guided multi-step workflows:
+
+| Prompt | Purpose |
+|--------|---------|
+| `read_docs_section` | Preview links with `list_links`, then crawl the relevant docs section |
+| `summarize_page` | Read a single URL and produce a concise, structured summary |
 
 ## Configuration
 

--- a/mcp_read_website/crawler.py
+++ b/mcp_read_website/crawler.py
@@ -8,6 +8,7 @@ import logging
 import re
 import socket
 from dataclasses import dataclass, field
+from typing import Awaitable, Callable
 from urllib.parse import urlparse, urljoin
 
 import html2text
@@ -46,6 +47,11 @@ _browser_config = BrowserConfig(
 )
 
 
+# Optional async callback invoked after each page is fetched during a crawl.
+# Signature: (fetched: int, total: int, current_url: str) -> Awaitable[None]
+ProgressCallback = Callable[[int, int, str], Awaitable[None]]
+
+
 @dataclass
 class CrawlResult:
     """Result of a website crawl."""
@@ -54,6 +60,9 @@ class CrawlResult:
     title: str | None = None
     links: list[str] = field(default_factory=list)
     error: str | None = None
+    pages_requested: int = 1
+    pages_fetched: int = 0
+    pages_failed: int = 0
 
 
 _PAYWALL_PATTERNS = re.compile(
@@ -278,6 +287,7 @@ async def _do_crawl(
     max_pages: int = 1,
     timeout: int = 30000,
     max_chars: int = 0,
+    progress: ProgressCallback | None = None,
 ) -> CrawlResult:
     """Internal crawl implementation with BFS link following."""
     visited: set[str] = set()
@@ -346,8 +356,16 @@ async def _do_crawl(
                     "error": f"Failed to fetch page: {exc}",
                 })
 
+            if progress is not None:
+                try:
+                    await progress(len(all_results), max_pages, current_url)
+                except Exception:
+                    logger.debug("progress callback failed", exc_info=True)
+
     if not all_results:
-        return CrawlResult(markdown="", error="No results returned")
+        return CrawlResult(
+            markdown="", error="No results returned", pages_requested=max_pages
+        )
 
     # Collect errors
     error_pages = [p for p in all_results if p.get("error")]
@@ -397,6 +415,9 @@ async def _do_crawl(
         title=all_results[0].get("title"),
         links=[link for page in all_results for link in page.get("links", [])],
         error=error_msg,
+        pages_requested=max_pages,
+        pages_fetched=len(success_pages),
+        pages_failed=len(error_pages),
     )
 
 
@@ -406,11 +427,16 @@ async def crawl_website(
     max_pages: int = 1,
     timeout: int = 30000,
     max_chars: int = 0,
+    progress: ProgressCallback | None = None,
 ) -> CrawlResult:
     """Crawl a website and return clean markdown.
 
     Uses iterative BFS to follow same-origin links up to max_pages.
     Enforces URL validation, concurrency limits, and overall timeout.
+
+    An optional ``progress`` async callback is invoked after each page with
+    ``(fetched, total, current_url)`` so callers (e.g. an MCP Context) can
+    surface progress on long multi-page crawls.
     """
     url = validate_url(url)
     logger.info("crawl_start url=%s max_pages=%d timeout=%d", url, max_pages, timeout)
@@ -418,7 +444,13 @@ async def crawl_website(
     try:
         async with crawl_semaphore:
             result = await asyncio.wait_for(
-                _do_crawl(url, max_pages=max_pages, timeout=timeout, max_chars=max_chars),
+                _do_crawl(
+                    url,
+                    max_pages=max_pages,
+                    timeout=timeout,
+                    max_chars=max_chars,
+                    progress=progress,
+                ),
                 timeout=MAX_CRAWL_SECONDS,
             )
     except asyncio.TimeoutError:
@@ -426,12 +458,15 @@ async def crawl_website(
         return CrawlResult(
             markdown="",
             error=f"Crawl timed out after {MAX_CRAWL_SECONDS}s. Try fewer pages or a shorter timeout.",
+            pages_requested=max_pages,
         )
     except ValueError:
         raise  # Re-raise URL validation errors
     except Exception as exc:
         logger.exception("crawl_error url=%s", url)
-        return CrawlResult(markdown="", error=f"Crawl failed: {exc}")
+        return CrawlResult(
+            markdown="", error=f"Crawl failed: {exc}", pages_requested=max_pages
+        )
 
     logger.info("crawl_complete url=%s pages=%d error=%s", url, len(result.links) > 0, result.error)
     return result

--- a/mcp_read_website/server.py
+++ b/mcp_read_website/server.py
@@ -8,7 +8,7 @@ from enum import Enum
 from typing import Annotated
 
 from fastmcp import Context, FastMCP
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from mcp_read_website.auth import BearerTokenVerifier
 from mcp_read_website.config import settings
@@ -111,13 +111,31 @@ class LinksResult(BaseModel):
 
 
 class CacheStatus(BaseModel):
-    """On-disk fetch cache statistics."""
+    """On-disk fetch cache statistics.
+
+    The wire (JSON) keys for size/files/formatted-size use the original
+    camelCase names (cacheSize, cacheFiles, cacheSizeFormatted) for
+    backward compatibility with existing clients. The model can still be
+    constructed using the snake_case field names (populate_by_name=True).
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
 
     cache_dir: str = Field(description="Filesystem path of the cache directory")
-    cache_size: int = Field(default=0, description="Total cache size in bytes")
-    cache_files: int = Field(default=0, description="Number of files in the cache")
+    cache_size: int = Field(
+        default=0,
+        serialization_alias="cacheSize",
+        description="Total cache size in bytes",
+    )
+    cache_files: int = Field(
+        default=0,
+        serialization_alias="cacheFiles",
+        description="Number of files in the cache",
+    )
     cache_size_formatted: str = Field(
-        default="0.00 MB", description="Human-readable cache size"
+        default="0.00 MB",
+        serialization_alias="cacheSizeFormatted",
+        description="Human-readable cache size",
     )
     error: str | None = Field(default=None, description="Error message; null on success")
 
@@ -170,8 +188,9 @@ async def read_website(
     Tip: call list_links first to preview available pages before a multi-page crawl.
 
     Returns a structured ReadResult (url, markdown, title, links, error, and
-    crawl page counts). The 'output' argument controls whether 'markdown' is
-    populated: 'json' omits it, 'markdown'/'both' include it.
+    crawl page counts). The 'markdown' field is populated for all output
+    modes ('markdown', 'json', and 'both'), matching the original behavior
+    where output='json' included the page content.
     """
     progress = None
     if ctx is not None:
@@ -201,8 +220,6 @@ async def read_website(
                 f"{len(result.links)} link(s) found"
             )
 
-    include_markdown = output in (OutputFormat.markdown, OutputFormat.both)
-
     # Raise only on a hard failure with no usable content in markdown mode,
     # preserving the original behavior.
     if (
@@ -212,9 +229,12 @@ async def read_website(
     ):
         raise ValueError(f"Failed to fetch content: {result.error}")
 
+    # All output modes ('markdown', 'json', 'both') include the markdown
+    # content. On 'main', output='json' returned a payload that contained
+    # the page content, so this preserves backward compatibility.
     return ReadResult(
         url=url,
-        markdown=result.markdown if include_markdown else "",
+        markdown=result.markdown or "",
         title=result.title,
         links=result.links or [],
         error=result.error,

--- a/mcp_read_website/server.py
+++ b/mcp_read_website/server.py
@@ -2,20 +2,50 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import shutil
 from enum import Enum
 from typing import Annotated
 
-from fastmcp import FastMCP
-from pydantic import Field
+from fastmcp import Context, FastMCP
+from pydantic import BaseModel, Field
 
 from mcp_read_website.auth import BearerTokenVerifier
 from mcp_read_website.config import settings
 from mcp_read_website.crawler import crawl_website, list_page_links
 
 logger = logging.getLogger(__name__)
+
+SERVER_INSTRUCTIONS = """\
+read-website-fast turns web pages into clean, token-efficient Markdown for
+reading and summarization. It strips nav, sidebars, and boilerplate (Mozilla
+Readability) and renders JavaScript-heavy pages (Crawl4AI / Playwright).
+
+Choosing a tool:
+- read_website — fetch one URL (pages=1, the default) or crawl a whole
+  same-origin section (pages=3-10) and get back clean Markdown plus the page
+  title and outbound links. This is the workhorse.
+- list_links — preview a page's title and links WITHOUT pulling full content.
+  Call this first when you are unsure which pages to read, then feed the chosen
+  URL into read_website. Much cheaper than a multi-page crawl for discovery.
+- get_cache_status / clear_cache — inspect or reset the on-disk fetch cache.
+
+Recommended workflow for reading a docs section:
+1. list_links(url) to see the table of contents.
+2. read_website(url, pages=N) on the most relevant entry point.
+
+Tuning:
+- pages: 1 for a single page; raise it (max 20) to follow same-origin links
+  via breadth-first crawl. Multi-page crawls report progress as they run.
+- max_chars: caps the returned characters (default 50000) to protect the
+  context window. Set 0 for unlimited.
+- output: 'markdown' (default) for reading, 'json' for structured
+  title+links+markdown, 'both' to get the rendered text and the JSON payload.
+
+This is a content-extraction tool, not a scraper: do not use it to bypass
+access controls or to bulk-harvest sites. Pages behind a paywall or login are
+detected and reported rather than circumvented.
+"""
 
 # Build authentication (bearer token via MCP_API_KEY). Fail-fast in HTTP mode.
 _auth = None
@@ -27,7 +57,7 @@ elif settings.transport == "http":
         "an unauthenticated server."
     )
 
-mcp = FastMCP("read-website-fast", auth=_auth)
+mcp = FastMCP("read-website-fast", instructions=SERVER_INSTRUCTIONS, auth=_auth)
 
 
 class OutputFormat(str, Enum):
@@ -36,14 +66,78 @@ class OutputFormat(str, Enum):
     both = "both"
 
 
+class ReadResult(BaseModel):
+    """Structured result of reading or crawling one or more web pages."""
+
+    url: str = Field(description="The (normalized) URL that was read")
+    markdown: str = Field(
+        default="",
+        description=(
+            "Clean Markdown content. For multi-page crawls, pages are "
+            "concatenated with source markers. Empty when output='json' or on "
+            "a hard failure."
+        ),
+    )
+    title: str | None = Field(default=None, description="Page title of the entry URL")
+    links: list[str] = Field(
+        default_factory=list,
+        description="Outbound links discovered while reading (de-duplicated)",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Error or warning message; null on full success",
+    )
+    pages_requested: int = Field(
+        default=1, description="Number of pages requested for the crawl"
+    )
+    pages_fetched: int = Field(
+        default=0, description="Number of pages successfully fetched"
+    )
+    pages_failed: int = Field(
+        default=0, description="Number of pages that failed to load"
+    )
+
+
+class LinksResult(BaseModel):
+    """Structured result of a lightweight link-discovery pass."""
+
+    url: str = Field(description="The (normalized) URL that was inspected")
+    title: str | None = Field(default=None, description="Page title")
+    links: list[str] = Field(
+        default_factory=list, description="Outbound links discovered on the page"
+    )
+    link_count: int = Field(default=0, description="Number of links returned")
+    error: str | None = Field(default=None, description="Error message; null on success")
+
+
+class CacheStatus(BaseModel):
+    """On-disk fetch cache statistics."""
+
+    cache_dir: str = Field(description="Filesystem path of the cache directory")
+    cache_size: int = Field(default=0, description="Total cache size in bytes")
+    cache_files: int = Field(default=0, description="Number of files in the cache")
+    cache_size_formatted: str = Field(
+        default="0.00 MB", description="Human-readable cache size"
+    )
+    error: str | None = Field(default=None, description="Error message; null on success")
+
+
+class CacheClearResult(BaseModel):
+    """Outcome of clearing the on-disk cache."""
+
+    status: str = Field(description="'success' or 'error'")
+    message: str = Field(description="Human-readable outcome message")
+
+
 @mcp.tool(
+    tags={"read"},
     annotations={
         "title": "Read Website",
         "readOnlyHint": True,
         "destructiveHint": False,
         "idempotentHint": True,
         "openWorldHint": True,
-    }
+    },
 )
 async def read_website(
     url: Annotated[str, Field(description="HTTP/HTTPS URL to fetch and convert to markdown")],
@@ -63,7 +157,8 @@ async def read_website(
         default=50000, ge=0, le=500000,
         description="Maximum characters to return. 0 for unlimited. Default 50000. Prevents context window overflow on large pages.",
     )] = 50000,
-) -> str:
+    ctx: Context | None = None,
+) -> ReadResult:
     """Fetch a web page and return clean Markdown. Handles JavaScript-rendered sites.
 
     Use pages=1 (default) for a single URL. Increase pages to follow same-origin
@@ -73,53 +168,71 @@ async def read_website(
     all outbound links — useful for deciding what to crawl next.
 
     Tip: call list_links first to preview available pages before a multi-page crawl.
+
+    Returns a structured ReadResult (url, markdown, title, links, error, and
+    crawl page counts). The 'output' argument controls whether 'markdown' is
+    populated: 'json' omits it, 'markdown'/'both' include it.
     """
+    progress = None
+    if ctx is not None:
+        if pages > 1:
+            await ctx.info(f"Crawling up to {pages} same-origin pages from {url}")
+        else:
+            await ctx.info(f"Reading {url}")
+
+        async def progress(fetched: int, total: int, current_url: str) -> None:
+            await ctx.report_progress(progress=fetched, total=total)
+            await ctx.debug(f"Fetched {fetched}/{total}: {current_url}")
+
     result = await crawl_website(
         url,
         max_pages=pages,
         timeout=timeout_seconds * 1000,
         max_chars=max_chars,
+        progress=progress,
     )
 
-    json_data = {
-        "markdown": result.markdown or "",
-        "title": result.title,
-        "links": result.links or [],
-        "url": url,
-        "error": result.error,
-    }
+    if ctx is not None:
+        if result.error:
+            await ctx.warning(result.error)
+        else:
+            await ctx.info(
+                f"Done: {result.pages_fetched} page(s) fetched, "
+                f"{len(result.links)} link(s) found"
+            )
 
-    if output == OutputFormat.json:
-        if result.error and not result.markdown:
-            return json.dumps({"markdown": "", "title": None, "links": [], "url": url, "error": result.error}, indent=2)
-        return json.dumps(json_data, indent=2)
+    include_markdown = output in (OutputFormat.markdown, OutputFormat.both)
 
-    if output == OutputFormat.both:
-        parts: list[str] = []
-        if result.error and result.markdown:
-            parts.append(f"**Warning:** {result.error}\n\n{result.markdown}")
-        elif result.markdown:
-            parts.append(result.markdown)
-        parts.append("<!-- JSON_DATA -->")
-        parts.append("```json\n" + json.dumps(json_data, indent=2) + "\n```")
-        return "\n\n".join(parts)
-
-    # Default: markdown
-    if result.error and result.markdown:
-        return f"**Warning:** {result.error}\n\n{result.markdown}"
-    if result.error and not result.markdown:
+    # Raise only on a hard failure with no usable content in markdown mode,
+    # preserving the original behavior.
+    if (
+        output == OutputFormat.markdown
+        and result.error
+        and not result.markdown
+    ):
         raise ValueError(f"Failed to fetch content: {result.error}")
-    return result.markdown
+
+    return ReadResult(
+        url=url,
+        markdown=result.markdown if include_markdown else "",
+        title=result.title,
+        links=result.links or [],
+        error=result.error,
+        pages_requested=result.pages_requested,
+        pages_fetched=result.pages_fetched,
+        pages_failed=result.pages_failed,
+    )
 
 
 @mcp.tool(
+    tags={"read"},
     annotations={
         "title": "List Links",
         "readOnlyHint": True,
         "destructiveHint": False,
         "idempotentHint": True,
         "openWorldHint": True,
-    }
+    },
 )
 async def list_links(
     url: Annotated[str, Field(description="URL to extract links from")],
@@ -131,7 +244,7 @@ async def list_links(
         default=30, ge=5, le=120,
         description="Timeout in seconds. Default 30.",
     )] = 30,
-) -> str:
+) -> LinksResult:
     """Returns the page title and all outbound links without returning full page content.
 
     Use this before read_website(pages=N) to preview what pages are available
@@ -142,52 +255,187 @@ async def list_links(
         same_origin_only=same_origin_only,
         timeout=timeout_seconds * 1000,
     )
-    return json.dumps(result, indent=2)
+    links = result.get("links", []) or []
+    return LinksResult(
+        url=result.get("url", url),
+        title=result.get("title"),
+        links=links,
+        link_count=result.get("link_count", len(links)),
+        error=result.get("error"),
+    )
+
+
+def _read_cache_status() -> CacheStatus:
+    """Compute cache statistics (shared by tool + resource)."""
+    cache_dir = settings.cache_dir
+    try:
+        if not cache_dir.exists():
+            return CacheStatus(cache_dir=str(cache_dir))
+
+        files = list(cache_dir.iterdir())
+        total_size = sum(f.stat().st_size for f in files if f.is_file())
+        return CacheStatus(
+            cache_dir=str(cache_dir),
+            cache_size=total_size,
+            cache_files=len(files),
+            cache_size_formatted=f"{total_size / 1024 / 1024:.2f} MB",
+        )
+    except Exception as e:
+        return CacheStatus(
+            cache_dir=str(cache_dir),
+            error=f"Failed to get cache status: {e}",
+        )
 
 
 @mcp.tool(
+    tags={"cache-admin"},
     annotations={
         "title": "Cache Status",
         "readOnlyHint": True,
         "destructiveHint": False,
         "idempotentHint": True,
         "openWorldHint": False,
-    }
+    },
 )
-async def get_cache_status() -> str:
+async def get_cache_status() -> CacheStatus:
     """Returns cache size and file count. Use before deciding whether to re-fetch a URL."""
-    cache_dir = settings.cache_dir
-    try:
-        if not cache_dir.exists():
-            return json.dumps({"cacheSize": 0, "cacheFiles": 0, "cacheSizeFormatted": "0.00 MB"}, indent=2)
-
-        files = list(cache_dir.iterdir())
-        total_size = sum(f.stat().st_size for f in files if f.is_file())
-        return json.dumps({
-            "cacheSize": total_size,
-            "cacheFiles": len(files),
-            "cacheSizeFormatted": f"{total_size / 1024 / 1024:.2f} MB",
-        }, indent=2)
-    except Exception as e:
-        return json.dumps({"error": "Failed to get cache status", "message": str(e)}, indent=2)
+    return _read_cache_status()
 
 
 @mcp.tool(
+    tags={"cache-admin"},
     annotations={
         "title": "Clear Cache",
         "readOnlyHint": False,
         "destructiveHint": True,
         "idempotentHint": True,
         "openWorldHint": False,
-    }
+    },
 )
-async def clear_cache() -> str:
+async def clear_cache(ctx: Context | None = None) -> CacheClearResult:
     """Clears the on-disk cache. Use when stale content is suspected or cache is too large."""
     try:
+        if ctx is not None:
+            await ctx.info(f"Clearing cache at {settings.cache_dir}")
         shutil.rmtree(settings.cache_dir, ignore_errors=True)
-        return json.dumps({"status": "success", "message": "Cache cleared successfully"}, indent=2)
+        return CacheClearResult(status="success", message="Cache cleared successfully")
     except Exception as e:
-        return json.dumps({"status": "error", "message": str(e)}, indent=2)
+        return CacheClearResult(status="error", message=str(e))
+
+
+# ---------------------------------------------------------------------------
+# Resources: readable reference/context data (no side effects).
+# ---------------------------------------------------------------------------
+
+
+@mcp.resource(
+    "readwebsite://cache/status",
+    name="Cache status",
+    description="Current on-disk fetch-cache size and file count.",
+    mime_type="application/json",
+    tags={"cache-admin"},
+)
+def cache_status_resource() -> CacheStatus:
+    """Expose cache statistics as a readable resource (context, not an action)."""
+    return _read_cache_status()
+
+
+@mcp.resource(
+    "readwebsite://config",
+    name="Server config",
+    description="Effective runtime configuration and operating limits.",
+    mime_type="application/json",
+    tags={"config"},
+)
+def config_resource() -> dict:
+    """Effective configuration and the hard limits enforced by the crawler."""
+    from mcp_read_website import crawler as _crawler
+
+    return {
+        "service": "read-website-fast",
+        "version": _version,
+        "transport": settings.transport,
+        "cache_dir": str(settings.cache_dir),
+        "auth_required": settings.mcp_api_key is not None,
+        "limits": {
+            "max_pages": 20,
+            "min_timeout_seconds": 5,
+            "max_timeout_seconds": 120,
+            "default_max_chars": 50000,
+            "max_chars_ceiling": 500000,
+            "max_page_chars": _crawler.MAX_PAGE_CHARS,
+            "max_total_chars": _crawler.MAX_TOTAL_CHARS,
+            "max_crawl_seconds": _crawler.MAX_CRAWL_SECONDS,
+            "max_concurrent_browsers": 3,
+            "inter_request_delay_seconds": _crawler.INTER_REQUEST_DELAY,
+        },
+    }
+
+
+@mcp.resource(
+    "readwebsite://usage",
+    name="Usage guide",
+    description="How to choose between the tools and tune crawl parameters.",
+    mime_type="text/markdown",
+    tags={"config"},
+)
+def usage_resource() -> str:
+    """Human/LLM-readable usage guidance (mirrors the server instructions)."""
+    return SERVER_INSTRUCTIONS
+
+
+# ---------------------------------------------------------------------------
+# Prompts: guided multi-step workflows.
+# ---------------------------------------------------------------------------
+
+
+@mcp.prompt(
+    name="read_docs_section",
+    description="Guide: preview a page's links, then crawl the relevant section into Markdown.",
+    tags={"read"},
+)
+def read_docs_section(
+    url: Annotated[str, Field(description="Entry URL of the docs section to read")],
+    topic: Annotated[
+        str, Field(description="What you are trying to learn or find")
+    ] = "",
+) -> str:
+    """Return a prompt that walks the model through the preview-then-crawl pattern."""
+    topic_line = f' focused on: "{topic}"' if topic else ""
+    return (
+        f"I want to read the documentation section at {url}{topic_line}.\n\n"
+        "Follow this workflow:\n"
+        f"1. Call list_links(url=\"{url}\") to preview the available pages "
+        "(title + same-origin links). Do NOT fetch full content yet.\n"
+        "2. From those links, pick the entry point and an appropriate `pages` "
+        "value (1 for a single page, 3-10 to read a whole section; max 20).\n"
+        f"3. Call read_website(url=..., pages=N) to pull the clean Markdown. "
+        "Keep max_chars at the default unless you need more.\n"
+        "4. Summarize the answer and cite the source URLs from the result's "
+        "`links`/source markers.\n\n"
+        "Prefer the smallest crawl that answers the question to stay "
+        "token-efficient."
+    )
+
+
+@mcp.prompt(
+    name="summarize_page",
+    description="Guide: read a single URL and produce a concise, structured summary.",
+    tags={"read"},
+)
+def summarize_page(
+    url: Annotated[str, Field(description="URL of the page to summarize")],
+) -> str:
+    """Return a prompt for a single-page read + structured summary."""
+    return (
+        f"Read {url} and summarize it.\n\n"
+        f"1. Call read_website(url=\"{url}\", pages=1).\n"
+        "2. If the result has an `error` indicating a paywall or login wall, "
+        "say so plainly rather than guessing the content.\n"
+        "3. Otherwise produce: a one-line TL;DR, 3-6 key points, and any "
+        "notable links from the result's `links`.\n"
+        "Keep it concise and faithful to the source."
+    )
 
 
 from datetime import datetime, timezone as _tz  # noqa: E402

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 requires-python = ">=3.12"
 authors = [{ name = "Casey Romkes" }]
 dependencies = [
-    "fastmcp>=3.2.4",
+    "fastmcp>=3.4.2,<4.0.0",
     "crawl4ai>=0.6.0",
     "pydantic>=2.10",
     "pydantic-settings>=2.12.0",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+import mcp_read_website.server as server_module
+from mcp_read_website.crawler import CrawlResult
 from mcp_read_website.server import mcp
 
 
@@ -91,3 +93,56 @@ class TestServerRegistration:
     async def test_server_has_instructions(self):
         assert mcp.instructions
         assert "read_website" in mcp.instructions
+
+
+class TestBackwardCompat:
+    """Guard the wire-compatible behavior that existing clients depend on."""
+
+    @pytest.mark.asyncio
+    async def test_cache_status_emits_camelcase_keys(self):
+        """get_cache_status must emit the original camelCase wire keys."""
+        tools = await mcp.list_tools()
+        tool = next(t for t in tools if t.name == "get_cache_status")
+
+        # Output schema must advertise the original camelCase keys.
+        mcp_tool = tool.to_mcp_tool()
+        schema_props = (mcp_tool.outputSchema or {}).get("properties", {})
+        for key in ("cacheSize", "cacheFiles", "cacheSizeFormatted"):
+            assert key in schema_props, f"missing camelCase key {key} in output schema"
+
+        # Actual structured data must also use the camelCase keys.
+        result = await tool.run({})
+        structured = result.structured_content
+        for key in ("cacheSize", "cacheFiles", "cacheSizeFormatted"):
+            assert key in structured, f"missing camelCase key {key} in structured output"
+        # snake_case variants must NOT leak onto the wire (back-compat).
+        for key in ("cache_size", "cache_files", "cache_size_formatted"):
+            assert key not in structured, f"snake_case key {key} leaked onto the wire"
+        # New additive key is allowed.
+        assert "cache_dir" in structured
+
+    @pytest.mark.asyncio
+    async def test_read_website_json_includes_markdown(self, monkeypatch):
+        """output='json' must include the markdown content, matching main."""
+
+        async def fake_crawl(url, **kwargs):
+            return CrawlResult(
+                markdown="# Hello\n\nbody text",
+                title="Hello",
+                links=["https://example.com/a"],
+                error=None,
+                pages_requested=1,
+                pages_fetched=1,
+                pages_failed=0,
+            )
+
+        monkeypatch.setattr(server_module, "crawl_website", fake_crawl)
+
+        tools = await mcp.list_tools()
+        tool = next(t for t in tools if t.name == "read_website")
+
+        result = await tool.run({"url": "https://example.com", "output": "json"})
+        structured = result.structured_content
+        assert structured["markdown"] == "# Hello\n\nbody text"
+        assert structured["title"] == "Hello"
+        assert structured["links"] == ["https://example.com/a"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -55,11 +55,39 @@ class TestServerRegistration:
         assert "same_origin_only" in props
 
     @pytest.mark.asyncio
-    async def test_no_resources_registered(self):
-        """Cache operations are now tools, not resources."""
+    async def test_read_website_returns_structured_output(self):
+        """read_website should advertise a structured output schema."""
+        tools = await mcp.list_tools()
+        tool = next(t for t in tools if t.name == "read_website")
+        mcp_tool = tool.to_mcp_tool()
+        assert mcp_tool.outputSchema is not None
+        props = mcp_tool.outputSchema.get("properties", {})
+        # Existing top-level fields must remain present.
+        for field in ("url", "markdown", "title", "links", "error"):
+            assert field in props
+
+    @pytest.mark.asyncio
+    async def test_reference_resources_registered(self):
+        """Cache status, config, and usage are exposed as readable resources."""
         resources = await mcp.list_resources()
-        assert len(resources) == 0
+        uris = {str(r.uri) for r in resources}
+        assert "readwebsite://cache/status" in uris
+        assert "readwebsite://config" in uris
+        assert "readwebsite://usage" in uris
+
+    @pytest.mark.asyncio
+    async def test_prompts_registered(self):
+        """Guided workflow prompts are available."""
+        prompts = await mcp.list_prompts()
+        names = {p.name for p in prompts}
+        assert "read_docs_section" in names
+        assert "summarize_page" in names
 
     @pytest.mark.asyncio
     async def test_server_name(self):
         assert mcp.name == "read-website-fast"
+
+    @pytest.mark.asyncio
+    async def test_server_has_instructions(self):
+        assert mcp.instructions
+        assert "read_website" in mcp.instructions

--- a/uv.lock
+++ b/uv.lock
@@ -697,35 +697,65 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.2.4"
+version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/18/46beaec18c9f86a599ae3f9cdf6677dd6b50240cfd844d18233710b47f13/fastmcp-3.4.2.tar.gz", hash = "sha256:b468722946fc467c3796a6572f7a14d93d48c014cf8fea12910245220cbbe4e1", size = 28756849, upload-time = "2026-06-06T01:30:35.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/4d/8b1ba42251160e11ca34686344572121432c23a082d56ef6bbdec5888fc1/fastmcp-3.4.2-py3-none-any.whl", hash = "sha256:c87a62b029f0c5400ada85f683629345d2466c39169f0cb853e487b2f7308c08", size = 8018, upload-time = "2026-06-06T01:30:38.118Z" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/2e/d627b28b7403ecc526991ef732921b08bde010006e6148635f053fd29f4c/fastmcp_slim-3.4.2.tar.gz", hash = "sha256:290646e0955a516235a317151034559aa48336cb843d3f006131aedad8759bb4", size = 576291, upload-time = "2026-06-06T01:30:12.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/58/22afebf18df7260b09148199cbeb90cdcc4b3a4e1b5d7460e3591c3a7add/fastmcp_slim-3.4.2-py3-none-any.whl", hash = "sha256:bdc72492212681ca502755fa8acc0457f559295da1fc3dfc0599adc1c04b82f3", size = 749195, upload-time = "2026-06-06T01:30:11.22Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
+]
+server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "griffelib" },
     { name = "httpx" },
+    { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
     { name = "opentelemetry-api" },
     { name = "packaging" },
-    { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
-    { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
-    { name = "rich" },
+    { name = "starlette" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
 ]
 
 [[package]]
@@ -1522,7 +1552,7 @@ dev = [
 requires-dist = [
     { name = "authlib", specifier = ">=1.7.0" },
     { name = "crawl4ai", specifier = ">=0.6.0" },
-    { name = "fastmcp", specifier = ">=3.2.4" },
+    { name = "fastmcp", specifier = ">=3.4.2,<4.0.0" },
     { name = "html2text", specifier = ">=2025.4.15" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
@@ -2845,15 +2875,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## fastmcp uplift — wrapper → first-class LLM asset

**Fully additive / backward-compatible** (after the review fixes below). No existing tool renamed or removed; no parameter changed. No new client-facing tools.

### What changed
- ⬆️ fastmcp pin → `>=3.4.2,<4.0.0`
- 🏷️ Tool annotations on **4** tools (readOnly / destructive / idempotent / openWorld + titles)
- 📦 **4** Pydantic output models → `output_schema`
- 📚 **3** `@mcp.resource` endpoints; 🧭 **2** `@mcp.prompt` workflows
- ⏳ `Context` progress/logging on multi-page crawls
- 📝 Server `instructions` set

### Review fixes applied (backward-compat)
Adversarial review caught two real regressions, both fixed before this PR:
1. **`get_cache_status` wire keys** had silently changed camelCase→snake_case. Restored `cacheSize` / `cacheFiles` / `cacheSizeFormatted` via `serialization_alias` + `populate_by_name=True` (the new `cache_dir` / `error` keys are additive).
2. **`output='json'` dropped the markdown content.** Restored so json-mode again includes the page content, matching base behavior.
Added a `TestBackwardCompat` suite covering both.

### Tests
`uv run pytest -q -m "not live"` → **38 passed, 15 deselected** (live tests need network); `ruff` clean.

---
🤖 Part of the 2026-06 MCP fleet uplift. Merging triggers the usual Komodo auto-deploy; live Tailscale smoke-test follows merge.